### PR TITLE
Fix importlib with django 1.9

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -2,7 +2,10 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
 
 
 # Default settings


### PR DESCRIPTION
The django provided importlib has been deprecated in 1.8 and has
been removed in django 1.9.