### PR TITLE
Adding placeholder support for PasswordInput in Django 1.4.

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -172,4 +172,6 @@ def is_widget_with_placeholder(widget):
     Only text, search, url, tel, e-mail, password, number have placeholders
     These are all derived form TextInput, except for Textarea
     """
-    return isinstance(widget, (TextInput, Textarea))
+    # PasswordInput inherits from Input in Django 1.4.
+    # It was changed to inherit from TextInput in 1.5.
+    return isinstance(widget, (TextInput, Textarea, PasswordInput))

--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 
 from django.contrib.admin.widgets import AdminFileWidget
 from django.forms import (
-    HiddenInput, FileInput, CheckboxSelectMultiple, Textarea, TextInput
+    HiddenInput, FileInput, CheckboxSelectMultiple, Textarea, TextInput,
+    PasswordInput
 )
 
 from .bootstrap import (

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -44,6 +44,7 @@ class TestForm(forms.Form):
         required=True,
         widget=forms.TextInput(attrs={'placeholder': 'placeholdertest'}),
     )
+    password = forms.CharField(widget=forms.PasswordInput)
     message = forms.CharField(required=False, help_text='<i>my_help_text</i>')
     sender = forms.EmailField(label='Sender © unicode')
     secret = forms.CharField(initial=42, widget=forms.HiddenInput)
@@ -265,6 +266,11 @@ class FieldTest(TestCase):
         res = render_form_field('subject')
         self.assertIn('type="text"', res)
         self.assertIn('placeholder="placeholdertest"', res)
+
+    def test_password(self):
+        res = render_form_field('password')
+        self.assertIn('type="password"', res)
+        self.assertIn('placeholder="Password"', res)
 
     def test_required_field(self):
         required_field = render_form_field('subject')


### PR DESCRIPTION
In Django 1.4, `PasswordInput` inherits from `Input`.  This patch fixes the bug and adds a test to show it's working in 1.4.

This relates to: #222.