### PR TITLE
Don't make checkboxes required by default.

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -5,6 +5,7 @@ from django.contrib.admin.widgets import AdminFileWidget
 from django.forms import (
     HiddenInput, FileInput, CheckboxSelectMultiple, Textarea, TextInput
 )
+from django.forms.widgets import CheckboxInput
 
 from .bootstrap import (
     get_bootstrap_setting, get_form_renderer, get_field_renderer,
@@ -161,7 +162,7 @@ def is_widget_required_attribute(widget):
     if isinstance(
             widget, (
                 AdminFileWidget, HiddenInput, FileInput,
-                CheckboxSelectMultiple)):
+                CheckboxInput, CheckboxSelectMultiple)):
         return False
     return True
 


### PR DESCRIPTION
Checkboxes almost always allow the user to choose between two states:
'on' or 'off'. It doesn't make sense to add the `required="required"`
attribute to them by default.