### PR TITLE
swap importlib imports

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 try:
-    from django.utils.importlib import import_module
-except ImportError:
     from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 # Default settings


### PR DESCRIPTION
using python importlib is now preferred, fixing deprecation warnings in django 1.8
```
/bootstrap3/bootstrap.py:6: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module
```