### PR TITLE
Switched CDN to maxcdn

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -11,7 +11,7 @@ except ImportError:
 # Default settings
 BOOTSTRAP3_DEFAULTS = {
     'jquery_url': '//code.jquery.com/jquery.min.js',
-    'base_url': '//netdna.bootstrapcdn.com/bootstrap/3.3.4/',
+    'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/',
     'css_url': None,
     'theme_url': None,
     'javascript_url': None,


### PR DESCRIPTION
From https://github.com/dyve/django-bootstrap3/issues/230,
this change is stated in
https://github.com/dyve/django-bootstrap3/blob/develop/HISTORY.rst
and
https://github.com/dyve/django-bootstrap3/blob/develop/docs/settings.rst.
But `BOOTSTRAP3_DEFAULTS` hasn't changed yet.