### PR TITLE
Issue #182: Errors and help text are now split into two seperat divs.

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -375,18 +375,15 @@ class FieldRenderer(BaseRenderer):
         return html
 
     def append_to_field(self, html):
-        help_text_and_errors = [self.field_help] + self.field_errors \
-            if self.field_help else self.field_errors
-        if help_text_and_errors:
-            help_html = get_template(
+        if self.field_help or self.field_errors:
+            html += get_template(
                 'bootstrap3/field_help_text_and_errors.html'
             ).render(Context({
                 'field': self.field,
-                'help_text_and_errors': help_text_and_errors,
+                'help_text': self.field_help,
+                'errors': self.field_errors,
                 'layout': self.layout,
             }))
-            html += '<span class="help-block">{help}</span>'.format(
-                help=help_html)
         return html
 
     def get_field_class(self):

--- a/bootstrap3/templates/bootstrap3/field_help_text_and_errors.html
+++ b/bootstrap3/templates/bootstrap3/field_help_text_and_errors.html
@@ -1,1 +1,6 @@
-{{ help_text_and_errors|join:' ' }}
+{% if errors %}
+<div class="help-block">{{ errors|join:'<br>' }}</div>
+{% endif %}
+{% if help_text %}
+<div class="help-block">{{ help_text }}</div>
+{% endif %}


### PR DESCRIPTION
As suggested, I split the help text and the error messages into two seperat divs. The errors are split with a linebreak.

Maybe we should use an unordered list for the errors for better styling?