### PR TITLE
Add FA icons template tag

### DIFF
--- a/bootstrap3/components.py
+++ b/bootstrap3/components.py
@@ -18,7 +18,7 @@ def render_icon(icon, title=''):
     return '<span{attrs}></span>'.format(attrs=flatatt(attrs))
 
 
-def render_fa_icon(icons, title=''):
+def render_fa_icon(icon, title=''):
     """
     Render a Font Awesome icon
     """

--- a/bootstrap3/components.py
+++ b/bootstrap3/components.py
@@ -18,6 +18,21 @@ def render_icon(icon, title=''):
     return '<span{attrs}></span>'.format(attrs=flatatt(attrs))
 
 
+def render_fa_icon(icons, title=''):
+    """
+    Render a Font Awesome icon
+    """
+
+    icons = ' '.join(['fa-' + item for item in icon.split(' ')])
+
+    attrs = {
+        'class': 'fa {icon}'.format(icon=icons),
+    }
+    if title:
+        attrs['title'] = title
+    return '<i{attrs}></i>'.format(attrs=flatatt(attrs))
+
+
 def render_alert(content, alert_type=None, dismissable=True):
     """
     Render a Bootstrap alert

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -17,7 +17,7 @@ from ..forms import (
     render_form_group, render_formset,
     render_label, render_form_errors, render_formset_errors
 )
-from ..components import render_icon, render_alert
+from ..components import render_icon, render_fa_icon, render_alert
 from ..utils import handle_var, parse_token_contents
 from ..text import force_text
 
@@ -407,7 +407,7 @@ def bootstrap_icon(icon, **kwargs):
 
 
 @register.simple_tag
-def bootstrap_fa_icon(icons, **kwargs):
+def bootstrap_fa_icon(icon, **kwargs):
     """
     Render an icon
 
@@ -428,9 +428,9 @@ def bootstrap_fa_icon(icons, **kwargs):
         {% bootstrap_icon "cog spin" %}
 
     """
-    return render_fa_icon(icons, **kwargs)
+    return render_fa_icon(icon, **kwargs)
 
-    
+
 @register.simple_tag
 def bootstrap_alert(content, alert_type='info', dismissable=True):
     """

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -407,6 +407,31 @@ def bootstrap_icon(icon, **kwargs):
 
 
 @register.simple_tag
+def bootstrap_fa_icon(icons, **kwargs):
+    """
+    Render an icon
+
+    **Tag name**::
+
+        bootstrap_fa_icon
+
+    **Parameters**:
+
+        :icons: icon name and modifiers like spin or lg
+
+    **usage**::
+
+        {% bootstrap_fa_icon "icon_name modifiers" %}
+
+    **example**::
+
+        {% bootstrap_icon "cog spin" %}
+
+    """
+    return render_fa_icon(icons, **kwargs)
+
+    
+@register.simple_tag
 def bootstrap_alert(content, alert_type='info', dismissable=True):
     """
     Render an alert

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -342,6 +342,15 @@ class ComponentsTest(TestCase):
             '<span class="glyphicon glyphicon-star" ' +
             'title="alpha centauri"></span>')
 
+    def test_fa_icon(self):
+        res = render_template('{% bootstrap_fa_icon "user" %}')
+        self.assertEqual(
+            res.strip(), '<i class="fa fa-user"></i>')
+
+        res = render_template('{% bootstrap_fa_icon "user lg" %}')
+        self.assertEqual(
+            res.strip(), '<i class="fa fa-user fa-lg"></i>')
+
     def test_alert(self):
         res = render_template(
             '{% bootstrap_alert "content" alert_type="danger" %}')


### PR DESCRIPTION
I'd prefer to add template tag for easy including [Font Awesome](http://fortawesome.github.io/Font-Awesome/icons/) icons into templates.

(sorry if I made something wrong, is my first pull request)