### PR TITLE
Added set_readonly to form field renderer

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -260,6 +260,7 @@ class FieldRenderer(BaseRenderer):
             self.required_css_class = ''
 
         self.set_disabled = kwargs.get('set_disabled', False)
+        self.set_readonly = kwargs.get('set_readonly', False)
 
     def restore_widget_attrs(self):
         self.widget.attrs = self.initial_attrs
@@ -309,6 +310,12 @@ class FieldRenderer(BaseRenderer):
         if self.set_disabled:
             widget.attrs['disabled'] = 'disabled'
 
+    def add_readonly_attrs(self, widget=None):
+        if widget is None:
+            widget = self.widget
+        if self.set_readonly:
+            widget.attrs['readonly'] = 'readonly'
+
     def add_widget_attrs(self):
         if self.is_multi_widget:
             widgets = self.widget.widgets
@@ -320,6 +327,7 @@ class FieldRenderer(BaseRenderer):
             self.add_help_attrs(widget)
             self.add_required_attrs(widget)
             self.add_disabled_attrs(widget)
+            self.add_readonly_attrs(widget)
 
     def list_to_class(self, html, klass):
         classes = add_css_class(klass, self.get_size_class())

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -382,6 +382,10 @@ class FieldTest(TestCase):
         self.assertIn('vDateField', field)
         self.assertIn('vTimeField', field)
 
+    def test_readonly(self):
+        template = render_template(
+            '{% bootstrap_field form.message set_readonly=True %}')
+        self.assertIn('readonly="readonly"', template)
 
 class ComponentsTest(TestCase):
     def test_icon(self):


### PR DESCRIPTION
Hi, I've added a "readonly" form field attribute renderer so you are able to make a form field readonly next to the option to make it disabled. I could not find any reason why it was not added yet so I've added it. I hope you like it and can use it.

Regards,

Peter