### PR TITLE
Don't escape HTML entity for space

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -7,6 +7,7 @@ from django.forms import (
     PasswordInput
 )
 from django.forms.widgets import CheckboxInput
+from django.utils.safestring import mark_safe
 
 from .bootstrap import (
     get_bootstrap_setting, get_form_renderer, get_field_renderer,
@@ -135,7 +136,7 @@ def render_field_and_label(
         if not field_class:
             field_class = get_bootstrap_setting('horizontal_field_class')
         if not label:
-            label = '&#160;'
+            label = mark_safe('&#160;')
         label_class = add_css_class(label_class, 'control-label')
     html = field
     if field_class:

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -455,7 +455,7 @@ class FieldRenderer(BaseRenderer):
         else:
             label = self.field.label
         if self.layout == 'horizontal' and not label:
-            return '&#160;'
+            return mark_safe('&#160;')
         return label
 
     def add_label(self, html):


### PR DESCRIPTION
Entity `&#160;` used as placeholder when label doesn't have value was escaped and it returned horrible results like this: ![snapshot3](https://cloud.githubusercontent.com/assets/2447438/9306254/671cfe8c-44f7-11e5-9f2d-a393451b5162.png)

This PR uses `mark_safe` method to make the entity look like space.