### PR TITLE
Added set_readonly parameter to bootstrap_field

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -21,6 +21,7 @@ BOOTSTRAP3_DEFAULTS = {
     'horizontal_field_class': 'col-md-9',
     'set_required': True,
     'set_disabled': False,
+    'set_readonly': False,
     'set_placeholder': True,
     'required_css_class': '',
     'error_css_class': 'has-error',

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -39,6 +39,7 @@ class BaseRenderer(object):
         self.exclude = kwargs.get('exclude', '')
         self.set_required = kwargs.get('set_required', True)
         self.set_disabled = kwargs.get('set_disabled', False)
+        self.set_readonly = kwargs.get('set_readonly', False)
         self.size = self.parse_size(kwargs.get('size', ''))
         self.horizontal_label_class = kwargs.get(
             'horizontal_label_class',
@@ -105,6 +106,7 @@ class FormsetRenderer(BaseRenderer):
                 exclude=self.exclude,
                 set_required=self.set_required,
                 set_disabled=self.set_disabled,
+                set_readonly=self.set_readonly,
                 size=self.size,
                 horizontal_label_class=self.horizontal_label_class,
                 horizontal_field_class=self.horizontal_field_class,
@@ -166,6 +168,7 @@ class FormRenderer(BaseRenderer):
                 exclude=self.exclude,
                 set_required=self.set_required,
                 set_disabled=self.set_disabled,
+                set_readonly=self.set_readonly,
                 size=self.size,
                 horizontal_label_class=self.horizontal_label_class,
                 horizontal_field_class=self.horizontal_field_class,
@@ -260,6 +263,7 @@ class FieldRenderer(BaseRenderer):
             self.required_css_class = ''
 
         self.set_disabled = kwargs.get('set_disabled', False)
+        self.set_readonly = kwargs.get('set_readonly', False)
 
     def restore_widget_attrs(self):
         self.widget.attrs = self.initial_attrs
@@ -308,6 +312,12 @@ class FieldRenderer(BaseRenderer):
             widget = self.widget
         if self.set_disabled:
             widget.attrs['disabled'] = 'disabled'
+            
+    def add_readonly_attrs(self, widget=None):
+        if widget is None:
+            widget = self.widget
+        if self.set_readonly:
+            widget.attrs['readonly'] = 'readonly'
 
     def add_widget_attrs(self):
         if self.is_multi_widget:
@@ -320,6 +330,7 @@ class FieldRenderer(BaseRenderer):
             self.add_help_attrs(widget)
             self.add_required_attrs(widget)
             self.add_disabled_attrs(widget)
+            self.add_readonly_attrs(widget)
 
     def list_to_class(self, html, klass):
         classes = add_css_class(klass, self.get_size_class())

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import ast
 from django.contrib.auth.forms import ReadOnlyPasswordHashWidget
 
 from django.forms import (
@@ -40,6 +41,7 @@ class BaseRenderer(object):
         self.set_required = kwargs.get('set_required', True)
         self.set_disabled = kwargs.get('set_disabled', False)
         self.set_readonly = kwargs.get('set_readonly', False)
+        self.input_extra = kwargs.get('input_extra', '')
         self.size = self.parse_size(kwargs.get('size', ''))
         self.horizontal_label_class = kwargs.get(
             'horizontal_label_class',
@@ -107,6 +109,7 @@ class FormsetRenderer(BaseRenderer):
                 set_required=self.set_required,
                 set_disabled=self.set_disabled,
                 set_readonly=self.set_readonly,
+                input_extra=self.input_extra,
                 size=self.size,
                 horizontal_label_class=self.horizontal_label_class,
                 horizontal_field_class=self.horizontal_field_class,
@@ -169,6 +172,7 @@ class FormRenderer(BaseRenderer):
                 set_required=self.set_required,
                 set_disabled=self.set_disabled,
                 set_readonly=self.set_readonly,
+                input_extra=self.input_extra,
                 size=self.size,
                 horizontal_label_class=self.horizontal_label_class,
                 horizontal_field_class=self.horizontal_field_class,
@@ -264,6 +268,7 @@ class FieldRenderer(BaseRenderer):
 
         self.set_disabled = kwargs.get('set_disabled', False)
         self.set_readonly = kwargs.get('set_readonly', False)
+        self.extra_attrs = kwargs.get('input_extra')
 
     def restore_widget_attrs(self):
         self.widget.attrs = self.initial_attrs
@@ -312,12 +317,20 @@ class FieldRenderer(BaseRenderer):
             widget = self.widget
         if self.set_disabled:
             widget.attrs['disabled'] = 'disabled'
-            
+
     def add_readonly_attrs(self, widget=None):
         if widget is None:
             widget = self.widget
         if self.set_readonly:
             widget.attrs['readonly'] = 'readonly'
+
+    def add_extra_attrs(self, widget=None):
+        if widget is None:
+            widget = self.widget
+        if self.extra_attrs:
+            temp_dict = widget.attrs.copy()
+            temp_dict.update(ast.literal_eval(self.extra_attrs))
+            widget.attrs = temp_dict
 
     def add_widget_attrs(self):
         if self.is_multi_widget:
@@ -331,6 +344,7 @@ class FieldRenderer(BaseRenderer):
             self.add_required_attrs(widget)
             self.add_disabled_attrs(widget)
             self.add_readonly_attrs(widget)
+            self.add_extra_attrs(widget)
 
     def list_to_class(self, html, klass):
         classes = add_css_class(klass, self.get_size_class())

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -383,6 +383,11 @@ def bootstrap_field(*args, **kwargs):
             When set to ``True`` then the ``disabled`` attribute is set on the rendered field.
 
             :default: ``False``
+            
+        set_readonly
+            When set to ``True`` then the ``readonly`` attribute is set on the rendered field.
+
+            :default: ``False``
 
         size
             Controls the size of the rendered ``div.form-group`` through the use of CSS classes.

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -383,11 +383,6 @@ def bootstrap_field(*args, **kwargs):
             When set to ``True`` then the ``disabled`` attribute is set on the rendered field.
 
             :default: ``False``
-            
-        set_readonly
-            When set to ``True`` then the ``readonly`` attribute is set on the rendered field.
-
-            :default: ``False``
 
         size
             Controls the size of the rendered ``div.form-group`` through the use of CSS classes.


### PR DESCRIPTION
Added set_readonly parameter to bootstrap_field for adding readonly attribute to rendered fields.

The "readonly" attribute has different behavior than "disabled" regarding form submissions. Disabled forms will not send their values in a POST request but readonly forms will.