### PR TITLE
Fix Deprecation warning in Django 1.9

### DIFF
--- a/bootstrap3/utils.py
+++ b/bootstrap3/utils.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import re
 
 from django.forms.widgets import flatatt
-from django.template import Variable, VariableDoesNotExist, Template, RequestContext
+from django.template import Variable, VariableDoesNotExist, Template, Context, RequestContext
 from django.template.base import FilterExpression, kwarg_re, TemplateSyntaxError
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
@@ -135,11 +135,16 @@ def render_template_to_unicode(template, context=None):
     """
     Render a Template to unicode
     """
-    if not isinstance(template, Template):
-        template = get_template(template)
-    if isinstance(context, RequestContext):
-        return template.render(context.flatten(), context.request)
     if context is None:
         context = {}
 
-    return template.render(context)
+    if not isinstance(template, Template):
+        template = get_template(template)
+        if isinstance(context, RequestContext):
+            return template.render(context.flatten(), context.request)
+        elif isinstance(context, Context):
+            return template.render(context.flatten())
+        else:
+            return template.render(context)
+    else:
+        return template.render(Context(context))

--- a/bootstrap3/utils.py
+++ b/bootstrap3/utils.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import re
 
 from django.forms.widgets import flatatt
-from django.template import Variable, VariableDoesNotExist, Template, Context
+from django.template import Variable, VariableDoesNotExist, Template, RequestContext
 from django.template.base import FilterExpression, kwarg_re, TemplateSyntaxError
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
@@ -137,6 +137,9 @@ def render_template_to_unicode(template, context=None):
     """
     if not isinstance(template, Template):
         template = get_template(template)
+    if isinstance(context, RequestContext):
+        return template.render(context.flatten(), context.request)
     if context is None:
         context = {}
-    return template.render(Context(context))
+
+    return template.render(context)


### PR DESCRIPTION
about first param to `template.render`:
```
[...]bootstrap3/utils.py:142: RemovedInDjango110Warning: render() must be called with a dict, not a Context.
  return template.render(Context(context))
```

Fixes #279 and #290