### PR TITLE
fixed bug with widget attrs consistency. #298

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -240,8 +240,8 @@ class FieldRenderer(BaseRenderer):
         else:
             self.placeholder = ''
 
-        self.addon_before = kwargs.get('addon_before', self.initial_attrs.pop('addon_before', ''))
-        self.addon_after = kwargs.get('addon_after', self.initial_attrs.pop('addon_after', ''))
+        self.addon_before = kwargs.get('addon_before', self.widget.attrs.pop('addon_before', ''))
+        self.addon_after = kwargs.get('addon_after', self.widget.attrs.pop('addon_after', ''))
 
         # These are set in Django or in the global BOOTSTRAP3 settings, and
         # they can be overwritten in the template
@@ -275,7 +275,7 @@ class FieldRenderer(BaseRenderer):
         self.set_disabled = kwargs.get('set_disabled', False)
 
     def restore_widget_attrs(self):
-        self.widget.attrs = self.initial_attrs
+        self.widget.attrs = self.initial_attrs.copy()
 
     def add_class_attrs(self, widget=None):
         if widget is None:

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -427,6 +427,17 @@ class FieldTest(TestCase):
         self.assertIn('vDateField', field)
         self.assertIn('vTimeField', field)
 
+    def test_field_same_render(self):
+        form = TestForm()
+        rendered_a = render_form_field("addon", form=form)
+        rendered_b = render_form_field("addon", form=form)
+        self.assertEqual(rendered_a, rendered_b)
+
+    def test_attributes_consistency(self):
+        form = TestForm()
+        attrs = form.fields['addon'].widget.attrs.copy()
+        field_alone = render_form_field("addon", form=form)
+        self.assertEqual(attrs, form.fields['addon'].widget.attrs)
 
 class ComponentsTest(TestCase):
     def test_icon(self):


### PR DESCRIPTION
after the _render of a widget via FieldRenderer, the attributes «addon_before» and «addon_after»
was removed and then, 2 render of the same field returned not always the same result

fix #298