### PR TITLE
Add subresource integrity

### DIFF
--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -11,10 +11,15 @@ except ImportError:
 # Default settings
 BOOTSTRAP3_DEFAULTS = {
     'jquery_url': '//code.jquery.com/jquery.min.js',
+    #'jquery_url': '//code.jquery.com/jquery-1.12.0.min.js',
+	'jquery_integrity': None,
     'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/',
     'css_url': None,
+	'css_integrity': None,
     'theme_url': None,
+	'theme_integrity': None,
     'javascript_url': None,
+	'javascript_integrity': None,
     'javascript_in_head': False,
     'include_jquery': False,
     'horizontal_label_class': 'col-md-3',
@@ -35,6 +40,14 @@ BOOTSTRAP3_DEFAULTS = {
         'default': 'bootstrap3.renderers.FieldRenderer',
         'inline': 'bootstrap3.renderers.InlineFieldRenderer',
     },
+}
+
+# Provides integrity values for pointed default version - https://www.srihash.org/ used
+BOOTSTRAP3_DEFAULT_INTEGRITY = {
+	'jquery': 'sha384-omOsxWjfyCQN/QkJa5gsN9F1sKX/IRXsLKvv7uHdTUYqkonYl4B/SrIIrNmrnJDj', # 1.11.0 'jquery.min.js'
+	#'jquery': 'sha384-XxcvoeNF5V0ZfksTnV+bejnCsJjOOIzN6UVwF85WBsAnU3zeYh5bloN+L4WLgeNE', # 1.12.0-min
+	'javascript': 'sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS', # js/bootstrap.min.js
+	'css': 'sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7', # css/bootstrap.min.css
 }
 
 # Start with a copy of default settings
@@ -65,12 +78,36 @@ def jquery_url():
     return get_bootstrap_setting('jquery_url')
 
 
+def jquery_integrity():
+	"""
+    Return the integrity tag value of jQuery file if provided or default version if used
+    """
+	if get_bootstrap_setting('jquery_integrity'):
+		return get_bootstrap_setting('jquery_integrity')
+	elif get_bootstrap_setting('jquery_url') == BOOTSTRAP3_DEFAULTS.get('jquery_url'):
+		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('jquery', None)
+	else:
+		return None
+
+
 def javascript_url():
     """
     Return the full url to the Bootstrap JavaScript file
     """
     return get_bootstrap_setting('javascript_url') or \
         bootstrap_url('js/bootstrap.min.js')
+
+
+def javascript_integrity():
+    """
+    Return the integrity tag value of JavaScript file if provided or default version if used
+    """
+	if get_bootstrap_setting('javascript_integrity'):
+		return get_bootstrap_setting('javascript_integrity')
+	elif not get_bootstrap_setting('javascript_url'):
+		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('javascript', None)
+	else:
+		return None
 
 
 def css_url():
@@ -81,11 +118,30 @@ def css_url():
         bootstrap_url('css/bootstrap.min.css')
 
 
+def css_integrity():
+    """
+    Return the integrity tag value of CSS file if provided or default version if used
+    """
+	if get_bootstrap_setting('css_integrity'):
+		return get_bootstrap_setting('css_integrity')
+	elif not get_bootstrap_setting('css_url'):
+		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('css', None)
+	else:
+		return None
+
+
 def theme_url():
     """
     Return the full url to the theme CSS file
     """
     return get_bootstrap_setting('theme_url')
+
+
+def theme_integrity():
+    """
+    Return the integrity tag value of Javascript file if provided or default version if used
+    """
+	return get_bootstrap_setting('theme_integrity')
 
 
 def get_renderer(renderers, **kwargs):

--- a/bootstrap3/bootstrap.py
+++ b/bootstrap3/bootstrap.py
@@ -12,14 +12,14 @@ except ImportError:
 BOOTSTRAP3_DEFAULTS = {
     'jquery_url': '//code.jquery.com/jquery.min.js',
     #'jquery_url': '//code.jquery.com/jquery-1.12.0.min.js',
-	'jquery_integrity': None,
+    'jquery_integrity': None,
     'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/',
     'css_url': None,
-	'css_integrity': None,
+    'css_integrity': None,
     'theme_url': None,
-	'theme_integrity': None,
+    'theme_integrity': None,
     'javascript_url': None,
-	'javascript_integrity': None,
+    'javascript_integrity': None,
     'javascript_in_head': False,
     'include_jquery': False,
     'horizontal_label_class': 'col-md-3',
@@ -44,10 +44,10 @@ BOOTSTRAP3_DEFAULTS = {
 
 # Provides integrity values for pointed default version - https://www.srihash.org/ used
 BOOTSTRAP3_DEFAULT_INTEGRITY = {
-	'jquery': 'sha384-omOsxWjfyCQN/QkJa5gsN9F1sKX/IRXsLKvv7uHdTUYqkonYl4B/SrIIrNmrnJDj', # 1.11.0 'jquery.min.js'
-	#'jquery': 'sha384-XxcvoeNF5V0ZfksTnV+bejnCsJjOOIzN6UVwF85WBsAnU3zeYh5bloN+L4WLgeNE', # 1.12.0-min
-	'javascript': 'sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS', # js/bootstrap.min.js
-	'css': 'sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7', # css/bootstrap.min.css
+    'jquery': 'sha384-omOsxWjfyCQN/QkJa5gsN9F1sKX/IRXsLKvv7uHdTUYqkonYl4B/SrIIrNmrnJDj', # 1.11.0 'jquery.min.js'
+    #'jquery': 'sha384-XxcvoeNF5V0ZfksTnV+bejnCsJjOOIzN6UVwF85WBsAnU3zeYh5bloN+L4WLgeNE', # 1.12.0-min
+    'javascript': 'sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS', # js/bootstrap.min.js
+    'css': 'sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7', # css/bootstrap.min.css
 }
 
 # Start with a copy of default settings
@@ -79,15 +79,15 @@ def jquery_url():
 
 
 def jquery_integrity():
-	"""
+    """
     Return the integrity tag value of jQuery file if provided or default version if used
     """
-	if get_bootstrap_setting('jquery_integrity'):
-		return get_bootstrap_setting('jquery_integrity')
-	elif get_bootstrap_setting('jquery_url') == BOOTSTRAP3_DEFAULTS.get('jquery_url'):
-		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('jquery', None)
-	else:
-		return None
+    if get_bootstrap_setting('jquery_integrity'):
+        return get_bootstrap_setting('jquery_integrity')
+    elif get_bootstrap_setting('jquery_url') == BOOTSTRAP3_DEFAULTS.get('jquery_url'):
+        return BOOTSTRAP3_DEFAULT_INTEGRITY.get('jquery', None)
+    else:
+        return None
 
 
 def javascript_url():
@@ -102,12 +102,12 @@ def javascript_integrity():
     """
     Return the integrity tag value of JavaScript file if provided or default version if used
     """
-	if get_bootstrap_setting('javascript_integrity'):
-		return get_bootstrap_setting('javascript_integrity')
-	elif not get_bootstrap_setting('javascript_url'):
-		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('javascript', None)
-	else:
-		return None
+    if get_bootstrap_setting('javascript_integrity'):
+        return get_bootstrap_setting('javascript_integrity')
+    elif not get_bootstrap_setting('javascript_url'):
+        return BOOTSTRAP3_DEFAULT_INTEGRITY.get('javascript', None)
+    else:
+        return None
 
 
 def css_url():
@@ -122,12 +122,12 @@ def css_integrity():
     """
     Return the integrity tag value of CSS file if provided or default version if used
     """
-	if get_bootstrap_setting('css_integrity'):
-		return get_bootstrap_setting('css_integrity')
-	elif not get_bootstrap_setting('css_url'):
-		return BOOTSTRAP3_DEFAULT_INTEGRITY.get('css', None)
-	else:
-		return None
+    if get_bootstrap_setting('css_integrity'):
+        return get_bootstrap_setting('css_integrity')
+    elif not get_bootstrap_setting('css_url'):
+        return BOOTSTRAP3_DEFAULT_INTEGRITY.get('css', None)
+    else:
+        return None
 
 
 def theme_url():
@@ -141,7 +141,7 @@ def theme_integrity():
     """
     Return the integrity tag value of Javascript file if provided or default version if used
     """
-	return get_bootstrap_setting('theme_integrity')
+    return get_bootstrap_setting('theme_integrity')
 
 
 def get_renderer(renderers, **kwargs):

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -11,7 +11,8 @@ from django.template import Context
 from django.utils.safestring import mark_safe
 
 from ..bootstrap import (
-    css_url, javascript_url, jquery_url, theme_url, get_bootstrap_setting
+    css_url, javascript_url, jquery_url, theme_url, get_bootstrap_setting, 
+	jquery_integrity, javascript_integrity, css_integrity, theme_integrity
 )
 from ..components import render_icon, render_alert
 from ..forms import (
@@ -94,6 +95,28 @@ def bootstrap_jquery_url():
 
 
 @register.simple_tag
+def bootstrap_jquery_integrity():
+    """
+    **Tag name**::
+
+        bootstrap_jquery_integrity
+
+    Return the integrity value set for the jQuery file
+
+    This value is configurable, see Settings section
+
+    **Usage**::
+
+        {% bootstrap_jquery_integrity %}
+
+    **Example**::
+
+        {% bootstrap_jquery_integrity %}
+    """
+    return jquery_integrity()
+
+
+@register.simple_tag
 def bootstrap_javascript_url():
     """
     Return the full url to the Bootstrap JavaScript library
@@ -115,6 +138,28 @@ def bootstrap_javascript_url():
         {% bootstrap_javascript_url %}
     """
     return javascript_url()
+
+
+@register.simple_tag
+def bootstrap_javascript_integrity():
+    """
+    **Tag name**::
+
+        bootstrap_javascript_integrity
+
+    Return the integrity value set for the JavaScript file
+
+    This value is configurable, see Settings section
+
+    **Usage**::
+
+        {% bootstrap_javascript_integrity %}
+
+    **Example**::
+
+        {% bootstrap_javascript_integrity %}
+    """
+    return javascript_integrity()
 
 
 @register.simple_tag
@@ -142,6 +187,28 @@ def bootstrap_css_url():
 
 
 @register.simple_tag
+def bootstrap_css_integrity():
+    """
+    Return the integrity value set for the Bootstrap CSS file
+
+    This value is configurable, see Settings section
+
+    **Tag name**::
+
+        bootstrap_css_integrity
+
+    **Usage**::
+
+        {% bootstrap_css_integrity %}
+
+    **Example**::
+
+        {% bootstrap_css_integrity %}
+    """
+    return css_integrity()
+
+
+@register.simple_tag
 def bootstrap_theme_url():
     """
     Return the full url to a Bootstrap theme CSS library
@@ -163,6 +230,28 @@ def bootstrap_theme_url():
         {% bootstrap_theme_url %}
     """
     return theme_url()
+
+
+@register.simple_tag
+def bootstrap_theme_integrity():
+    """
+    Return the integrity value set for the CSS theme file
+
+    This value is configurable, see Settings section
+
+    **Tag name**::
+
+        bootstrap_theme_integrity
+
+    **Usage**::
+
+        {% bootstrap_theme_integrity %}
+
+    **Example**::
+
+        {% bootstrap_theme_integrity %}
+    """
+    return theme_integrity()
 
 
 @register.simple_tag
@@ -189,8 +278,10 @@ def bootstrap_css():
 
         {% bootstrap_css %}
     """
-    urls = [url for url in [bootstrap_css_url(), bootstrap_theme_url()] if url]
-    return mark_safe(''.join([render_link_tag(url) for url in urls]))
+    urls = [(url, integrity) for (url, integrity) in zip(
+		[bootstrap_css_url(), bootstrap_theme_url()],
+		[bootstrap_css_integrity(), bootstrap_theme_integrity()]) if url]
+    return mark_safe(''.join([render_link_tag(url, integrity=integrity) for (url, integrity) in urls]))
 
 
 @register.simple_tag
@@ -231,10 +322,18 @@ def bootstrap_javascript(jquery=None):
     if jquery:
         url = bootstrap_jquery_url()
         if url:
-            javascript += render_tag('script', attrs={'src': url})
+			jquery_attrs = {'src': url}
+			jquery_integrity = bootstrap_jquery_integrity()
+			if jquery_integrity:
+				jquery_attrs.update({'integrity': jquery_integrity, 'crossorigin': 'anonymous'})
+            javascript += render_tag('script', attrs=jquery_attrs)
     url = bootstrap_javascript_url()
     if url:
-        javascript += render_tag('script', attrs={'src': url})
+		javascript_attrs = {'src': url}
+		javascript_integrity = bootstrap_javascript_integrity()
+		if javascript_integrity: # This should probably be in render_tag but author seems to reserve it for general rendering
+			javascript_attrs.update({'integrity': javascript_integrity, 'crossorigin': 'anonymous'})
+        javascript += render_tag('script', attrs=javascript_attrs)
     return mark_safe(javascript)
 
 

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -12,7 +12,7 @@ from django.utils.safestring import mark_safe
 
 from ..bootstrap import (
     css_url, javascript_url, jquery_url, theme_url, get_bootstrap_setting, 
-	jquery_integrity, javascript_integrity, css_integrity, theme_integrity
+    jquery_integrity, javascript_integrity, css_integrity, theme_integrity
 )
 from ..components import render_icon, render_alert
 from ..forms import (
@@ -279,8 +279,9 @@ def bootstrap_css():
         {% bootstrap_css %}
     """
     urls = [(url, integrity) for (url, integrity) in zip(
-		[bootstrap_css_url(), bootstrap_theme_url()],
-		[bootstrap_css_integrity(), bootstrap_theme_integrity()]) if url]
+            [bootstrap_css_url(), bootstrap_theme_url()],
+            [bootstrap_css_integrity(), bootstrap_theme_integrity()]
+        ) if url]
     return mark_safe(''.join([render_link_tag(url, integrity=integrity) for (url, integrity) in urls]))
 
 
@@ -322,17 +323,17 @@ def bootstrap_javascript(jquery=None):
     if jquery:
         url = bootstrap_jquery_url()
         if url:
-			jquery_attrs = {'src': url}
-			jquery_integrity = bootstrap_jquery_integrity()
-			if jquery_integrity:
-				jquery_attrs.update({'integrity': jquery_integrity, 'crossorigin': 'anonymous'})
+            jquery_attrs = {'src': url}
+            jquery_integrity = bootstrap_jquery_integrity()
+            if jquery_integrity:
+                jquery_attrs.update({'integrity': jquery_integrity, 'crossorigin': 'anonymous'})
             javascript += render_tag('script', attrs=jquery_attrs)
     url = bootstrap_javascript_url()
     if url:
-		javascript_attrs = {'src': url}
-		javascript_integrity = bootstrap_javascript_integrity()
-		if javascript_integrity: # This should probably be in render_tag but author seems to reserve it for general rendering
-			javascript_attrs.update({'integrity': javascript_integrity, 'crossorigin': 'anonymous'})
+        javascript_attrs = {'src': url}
+        javascript_integrity = bootstrap_javascript_integrity()
+        if javascript_integrity: # This should probably be in render_tag but author seems to reserve it for general rendering
+            javascript_attrs.update({'integrity': javascript_integrity, 'crossorigin': 'anonymous'})
         javascript += render_tag('script', attrs=javascript_attrs)
     return mark_safe(javascript)
 

--- a/bootstrap3/utils.py
+++ b/bootstrap3/utils.py
@@ -102,7 +102,7 @@ def remove_css_class(css_classes, css_class):
     return ' '.join(classes_list)
 
 
-def render_link_tag(url, rel='stylesheet', media=None):
+def render_link_tag(url, rel='stylesheet', media=None, integrity=None):
     """
     Build a link tag
     """
@@ -112,6 +112,9 @@ def render_link_tag(url, rel='stylesheet', media=None):
     }
     if media:
         attrs['media'] = media
+    if integrity:
+        attrs['integrity'] = integrity
+        attrs['crossorigin'] = 'anonymous'
     return render_tag('link', attrs=attrs, close=False)
 
 


### PR DESCRIPTION
Add subresource integrity (to close #304), with default values.
jQuery URL should be set to a fixed version (like in the commented line ; jQuery website's doesn't mention the non-versionned uri and it seems stuck on 1.11.0)