### PR TITLE
update documentation with correct value

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -500,7 +500,7 @@ def bootstrap_label(*args, **kwargs):
 
     **Example**::
 
-        {% bootstrap_label "Email address" for="exampleInputEmail1" %}
+        {% bootstrap_label "Email address" label_for="exampleInputEmail1" %}
 
     """
     return render_label(*args, **kwargs)


### PR DESCRIPTION
'bootstrap_label' has parameter 'label_for' and not 'for', I have updated this for the documentation part