### PR TITLE
Added support for addon_before_class and addon_after_class

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -241,6 +241,8 @@ class FieldRenderer(BaseRenderer):
 
         self.addon_before = kwargs.get('addon_before', self.widget.attrs.pop('addon_before', ''))
         self.addon_after = kwargs.get('addon_after', self.widget.attrs.pop('addon_after', ''))
+        self.addon_before_class = kwargs.get('addon_before_class', self.widget.attrs.pop('addon_before_class', 'input-group-addon'))
+        self.addon_after_class = kwargs.get('addon_after_class', self.widget.attrs.pop('addon_after_class', 'input-group-addon'))
 
         # These are set in Django or in the global BOOTSTRAP3 settings, and
         # they can be overwritten in the template
@@ -404,10 +406,10 @@ class FieldRenderer(BaseRenderer):
 
     def make_input_group(self, html):
         if (self.addon_before or self.addon_after) and isinstance(self.widget, (TextInput, DateInput, Select)):
-            before = '<span class="input-group-addon">{addon}</span>'.format(
-                addon=self.addon_before) if self.addon_before else ''
-            after = '<span class="input-group-addon">{addon}</span>'.format(
-                addon=self.addon_after) if self.addon_after else ''
+            before = '<span class="{input_class}">{addon}</span>'.format(
+                input_class=self.addon_before_class, addon=self.addon_before) if self.addon_before else ''
+            after = '<span class="{input_class}">{addon}</span>'.format(
+                input_class=self.addon_after_class, addon=self.addon_after) if self.addon_after else ''
             html = '<div class="input-group">{before}{html}{after}</div>'.format(
                 before=before,
                 after=after,

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -445,6 +445,26 @@ def bootstrap_field(*args, **kwargs):
             Text that should be appended to the form field. See the `Bootstrap docs <http://getbootstrap.com/components/#input-groups-basic>`_
             for an example.
 
+        addon_before_class
+            Class used on the span when ``addon_before`` is used.
+
+            One of the following values:
+                
+                * ``'input-group-addon'``
+                * ``'input-group-btn'``
+
+            :default: ``input-group-addon``
+
+        addon_after_class
+            Class used on the span when ``addon_after`` is used.
+
+            One of the following values:
+                
+                * ``'input-group-addon'``
+                * ``'input-group-btn'``
+
+            :default: ``input-group-addon``
+
         error_css_class
             CSS class used when the field has an error
 

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -422,6 +422,12 @@ class FieldTest(TestCase):
         self.assertIn('class="input-group-addon">$', res)
         self.assertIn('class="input-group-addon">.00', res)
 
+    def test_input_group_addon_button(self):
+        res = render_template_with_form('{% bootstrap_field form.subject addon_before="$" addon_before_class="input-group-btn" addon_after=".00" addon_after_class="input-group-btn" %}')
+        self.assertIn('class="input-group"', res)
+        self.assertIn('class="input-group-btn">$', res)
+        self.assertIn('class="input-group-btn">.00', res)
+
     def test_size(self):
         def _test_size(param, klass):
             res = render_template_with_form('{% bootstrap_field form.subject size="' + param + '" %}')


### PR DESCRIPTION
This pull request adds support for addon_before_class and addon_after_class options as described in issue #295. Both default to input-group-addon to maintain compatibility with existing code.