### PR TITLE
Print form field help text and error messages with proper line breaks

### DIFF
--- a/bootstrap3/templates/bootstrap3/field_help_text_and_errors.html
+++ b/bootstrap3/templates/bootstrap3/field_help_text_and_errors.html
@@ -1,1 +1,4 @@
-{{ help_text_and_errors|join:' ' }}
+{# Reverse the messages, so that errors are printed first #}
+{% for text in help_text_and_errors reversed %}
+    <div class="help-block">{{ text }}</div>
+{% endfor %}


### PR DESCRIPTION
Fixes #182 

Instead of doing a simple string concatenation, help text and error messages are now printed inside their own help text blocks.