### PR TITLE
Adapted LANGUAGE_CODE implementation in template

### DIFF
--- a/bootstrap3/templates/bootstrap3/bootstrap3.html
+++ b/bootstrap3/templates/bootstrap3/bootstrap3.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {% load bootstrap3 %}
-<html{% if request.LANGUAGE_CODE %} lang="{{ request.LANGUAGE_CODE }}"{% endif %}>
+<html{% if LANGUAGE_CODE %} lang="{{ LANGUAGE_CODE }}"{% endif %}>
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
As stated [here](https://docs.djangoproject.com/en/1.10/ref/templates/api/#django-template-context-processors-i18n) in Django v1.10 documentation the `request.LANGUAGE_CODE` existence is checked by the context processor itself. Using the `request.LANGUAGE_CODE` directly does not guarantee a valid language code even if one is properly set in django settings module.