### PR TITLE
Fix #268: 'warning: no files found matching X under directory Y

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
-recursive-include bootstrap3 *.html *.png *.gif *js *jpg *jpeg *svg *py
-recursive-include demo *.html *.png *.gif *js *jpg *jpeg *svg *py
+recursive-include bootstrap3 *
+recursive-include demo *


### PR DESCRIPTION
These warnings were due to absent filetypes being looked for based on the contents of `MANIFEST.in`. This PR fixes those warnings both at the time of creating the package and at the time of installing.