### PR TITLE
Add support for subresource integrity (SRI)

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -31,6 +31,12 @@ MESSAGE_LEVEL_CLASSES = {
     DEFAULT_MESSAGE_LEVELS.ERROR: "alert alert-danger",
 }
 
+INTEGRITY = {
+    "css": r"sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u",
+    "theme": r"sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp",
+    "javascript": r"sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa",
+}
+
 register = template.Library()
 
 
@@ -189,8 +195,12 @@ def bootstrap_css():
 
         {% bootstrap_css %}
     """
-    urls = [url for url in [bootstrap_css_url(), bootstrap_theme_url()] if url]
-    return mark_safe(''.join([render_link_tag(url) for url in urls]))
+    rendered_urls = render_link_tag(
+        bootstrap_css_url(), integrity=INTEGRITY['css'])
+    if bootstrap_theme_url():
+        rendered_urls.append(
+            render_link_tag(bootstrap_css_url(), integrity=INTEGRITY['theme']))
+    return mark_safe(''.join([url for url in rendered_urls]))
 
 
 @register.simple_tag
@@ -234,7 +244,11 @@ def bootstrap_javascript(jquery=None):
             javascript += render_tag('script', attrs={'src': url})
     url = bootstrap_javascript_url()
     if url:
-        javascript += render_tag('script', attrs={'src': url})
+        attrs = {'src': url}
+        if INTEGRITY['javascript']:
+            attrs['integrity'] = INTEGRITY['javascript']
+            attrs['crossorigin'] = 'anonymous'
+        javascript += render_tag('script', attrs=attrs)
     return mark_safe(javascript)
 
 

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -201,15 +201,16 @@ class SettingsTest(TestCase):
         res = render_template_with_form('{% bootstrap_javascript %}')
         self.assertEqual(
             res.strip(),
-            '<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>'
+            '<script crossorigin="anonymous" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>'
         )
 
     def test_bootstrap_css_tag(self):
+        self.maxDiff = None
         res = render_template_with_form('{% bootstrap_css %}')
-        self.assertIn(res.strip(), [
-            '<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">',
-            '<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">',
-        ])
+        self.assertEqual(
+            res.strip(),
+            '<link crossorigin="anonymous" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" rel="stylesheet">'
+        )
 
     def test_settings_filter(self):
         res = render_template_with_form('{{ "required_css_class"|bootstrap_setting }}')

--- a/bootstrap3/utils.py
+++ b/bootstrap3/utils.py
@@ -112,7 +112,7 @@ def remove_css_class(css_classes, css_class):
     return ' '.join(classes_list)
 
 
-def render_link_tag(url, rel='stylesheet', media=None):
+def render_link_tag(url, rel='stylesheet', integrity=None, media=None):
     """
     Build a link tag
     """
@@ -120,6 +120,9 @@ def render_link_tag(url, rel='stylesheet', media=None):
         'href': url,
         'rel': rel,
     }
+    if integrity:
+        attrs['integrity'] = integrity
+        attrs['crossorigin'] = 'anonymous'
     if media:
         attrs['media'] = media
     return render_tag('link', attrs=attrs, close=False)


### PR DESCRIPTION
Added 'integrity' and 'crossorigin' attributes to Bootstrap's CSS and JS links. This is recommended in the Bootstrap docs and elsewhere:

- http://getbootstrap.com/getting-started/#download-cdn
- https://hacks.mozilla.org/2015/09/subresource-integrity-in-firefox-43/
- https://www.w3.org/TR/SRI/