### PR TITLE
No models for the demo application, removed sqlite3 database dependency

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -15,12 +15,7 @@ DEBUG = True
 
 ADMINS = ()
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-    }
-}
+DATABASES = {}
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts


### PR DESCRIPTION
Small modification to the settings.py attached to the "demo" application. Given that no models.py are defined for the app, we can safely remove the sqlite database dependency.