### PR TITLE
Add back support for message|safe using extra_tags

### DIFF
--- a/bootstrap3/templates/bootstrap3/messages.html
+++ b/bootstrap3/templates/bootstrap3/messages.html
@@ -2,6 +2,10 @@
 {% for message in messages %}
     <div class="{{ message|bootstrap_message_classes }} alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
-        {{ message }}
+        {% if 'is_safe' in message.extra_tags %}
+          {{ message|safe }}
+        {% else %}
+          {{ message }}
+        {% endif %}
     </div>
 {% endfor %}

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -457,7 +457,7 @@ def bootstrap_field(*args, **kwargs):
             Class used on the span when ``addon_before`` is used.
 
             One of the following values:
-                
+
                 * ``'input-group-addon'``
                 * ``'input-group-btn'``
 
@@ -467,7 +467,7 @@ def bootstrap_field(*args, **kwargs):
             Class used on the span when ``addon_after`` is used.
 
             One of the following values:
-                
+
                 * ``'input-group-addon'``
                 * ``'input-group-btn'``
 

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -502,6 +502,7 @@ class ComponentsTest(TestCase):
 
 class MessagesTest(TestCase):
     def test_messages(self):
+        self.maxDiff=None
         class FakeMessage(object):
             """
             Follows the `django.contrib.messages.storage.base.Message` API.
@@ -521,7 +522,7 @@ class MessagesTest(TestCase):
         pattern = re.compile(r'\s+')
         messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.WARNING, "hello")]
         res = render_template_with_form(
-            '{% bootstrap_messages messages %}', {'messages': messages})
+            '{% bootstrap_messages %}', {'messages': messages})
         expected = """
     <div class="alert alert-warning alert-dismissable">
         <button type="button" class="close" data-dismiss="alert"
@@ -536,7 +537,7 @@ class MessagesTest(TestCase):
 
         messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.ERROR, "hello")]
         res = render_template_with_form(
-            '{% bootstrap_messages messages %}', {'messages': messages})
+            '{% bootstrap_messages %}', {'messages': messages})
         expected = """
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert"
@@ -551,7 +552,7 @@ class MessagesTest(TestCase):
 
         messages = [FakeMessage(None, "hello")]
         res = render_template_with_form(
-            '{% bootstrap_messages messages %}', {'messages': messages})
+            '{% bootstrap_messages %}', {'messages': messages})
         expected = """
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert"
@@ -567,7 +568,7 @@ class MessagesTest(TestCase):
 
         messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.ERROR, "hello http://example.com")]
         res = render_template_with_form(
-            '{% bootstrap_messages messages %}', {'messages': messages})
+            '{% bootstrap_messages %}', {'messages': messages})
         expected = """
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
@@ -580,12 +581,43 @@ class MessagesTest(TestCase):
 
         messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.ERROR, "hello\nthere")]
         res = render_template_with_form(
-            '{% bootstrap_messages messages %}', {'messages': messages})
+            '{% bootstrap_messages %}', {'messages': messages})
         expected = """
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert"
             aria-hidden="true">&#215;</button>
         hello there
+    </div>
+        """
+        self.assertEqual(
+            re.sub(pattern, '', res),
+            re.sub(pattern, '', expected)
+        )
+
+        link = '<a href="http://getbootstrap.com/">Get Bootstrap</a>'
+        messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.ERROR, link)]
+        res = render_template_with_form(
+            '{% bootstrap_messages %}', {'messages': messages})
+        expected = """
+    <div class="alert alert-danger alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert"
+            aria-hidden="true">&#215;</button>
+        &lt;a href=&quot;http://getbootstrap.com/&quot;&gt;Get Bootstrap&lt;/a&gt;
+    </div>
+        """
+        self.assertEqual(
+            re.sub(pattern, '', res),
+            re.sub(pattern, '', expected)
+        )
+
+        messages = [FakeMessage(DEFAULT_MESSAGE_LEVELS.ERROR, link, extra_tags='is_safe')]
+        res = render_template_with_form(
+            '{% bootstrap_messages %}', {'messages': messages})
+        expected = """
+    <div class="is_safe alert alert-danger alert-dismissable">
+        <button type="button" class="close" data-dismiss="alert"
+            aria-hidden="true">&#215;</button>
+        <a href="http://getbootstrap.com/">Get Bootstrap</a>
     </div>
         """
         self.assertEqual(

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -502,7 +502,6 @@ class ComponentsTest(TestCase):
 
 class MessagesTest(TestCase):
     def test_messages(self):
-        self.maxDiff=None
         class FakeMessage(object):
             """
             Follows the `django.contrib.messages.storage.base.Message` API.


### PR DESCRIPTION
I noticed you removed the `safe` filter on each `message` sometime back, which is great security-wise, but I feel that should be an option for messages we know are safe.

This won't break any existing code, which will continue to be secure by default, but adds the option for the message to be rendered with the `safe` filter if its extra tags are set. I'd love if this were possible.

This issue was first raised in #188 and fixed in #306 as it says there, but I don't think the suggestion to use extra_tags to allow safe messages as per convention was followed through.

Thank you for your hard work!