### PR TITLE
Documentation fix: set_disabled refers to required attribute.

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -432,7 +432,7 @@ def bootstrap_field(*args, **kwargs):
 
         set_disabled
             When set to ``True`` then the ``disabled`` attribute is set on the rendered field. This only
-            works up to Django 1.8.  Higher Django versions handle ``required`` natively.
+            works up to Django 1.8.  Higher Django versions handle ``disabled`` natively.
 
             :default: ``False``
 


### PR DESCRIPTION
Noticed this while reading through the documentation yesterday. I think this was a copy and paste error from the `set_required` directly above it.