### PR TITLE
Fix theme_url option or twice css_url in head html

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -191,7 +191,7 @@ def bootstrap_css():
     """
     rendered_urls = [render_link_tag(bootstrap_css_url()), ]
     if bootstrap_theme_url():
-        rendered_urls.append(render_link_tag(bootstrap_css_url()))
+        rendered_urls.append(render_link_tag(bootstrap_theme_url()))
     return mark_safe(''.join([url for url in rendered_urls]))
 
 


### PR DESCRIPTION
Option `theme_url` not work, because used function `bootstrap_css_url` instead `bootstrap_theme_url`
Affected releases: `8.0.0`, `8.1.0` and current `master` branch.
Latest release **without** this bug: `7.1.0`