### PR TITLE
Avoid import deprecation in Django 2.0

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -11,7 +11,12 @@ from django.forms import (
     TextInput, DateInput, FileInput, CheckboxInput, MultiWidget,
     ClearableFileInput, Select, RadioSelect, CheckboxSelectMultiple
 )
-from django.forms.extras import SelectDateWidget
+# Django 1.9 moved SelectDateWidget to django.forms.widget from
+# django.forms.extras. Django 2.0 will remove the old import location.
+try:
+    from django.forms.widgets import SelectDateWidget
+except ImportError:
+    from django.forms.extras import SelectDateWidget
 from django.forms.forms import BaseForm, BoundField
 from django.forms.formsets import BaseFormSet
 from django.utils.html import conditional_escape, escape, strip_tags


### PR DESCRIPTION
I've been getting a warning about deprecated imports while running Django 1.10.5:
> /usr/local/venv/local/lib/python2.7/site-packages/bootstrap3/renderers.py:14: RemovedInDjango20Warning: django.forms.extras is deprecated. You can find SelectDateWidget in django.forms.widgets instead.

This seems easy enough to avoid (and to make django-bootstrap3 forward compatible).