### PR TITLE
Adding value option to field

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -247,6 +247,11 @@ class FieldRenderer(BaseRenderer):
         self.field_help = text_value(mark_safe(field.help_text)) if self.show_help and field.help_text else ''
         self.field_errors = [conditional_escape(text_value(error)) for error in field.errors]
 
+        if 'value' in kwargs:
+            self.value = kwargs['value']
+        else:
+            self.value = ''
+
         if 'placeholder' in kwargs:
             # Find the placeholder in kwargs, even if it's empty
             self.placeholder = kwargs['placeholder']
@@ -325,6 +330,13 @@ class FieldRenderer(BaseRenderer):
             # TODO: Should this be stripped and/or escaped?
             widget.attrs['placeholder'] = placeholder
 
+    def add_value_attrs(self, widget=None):
+        if widget is None:
+            widget = self.widget
+        value = widget.attrs.get('value', self.value)
+        if value:
+            widget.attrs['value'] = value
+
     def add_help_attrs(self, widget=None):
         if widget is None:
             widget = self.widget
@@ -360,6 +372,7 @@ class FieldRenderer(BaseRenderer):
         for widget in widgets:
             self.add_class_attrs(widget)
             self.add_placeholder_attrs(widget)
+            self.add_value_attrs(widget)
             self.add_help_attrs(widget)
             if DBS3_SET_REQUIRED_SET_DISABLED:
                 self.add_required_attrs(widget)

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -425,6 +425,9 @@ def bootstrap_field(*args, **kwargs):
 
             :default: ``False``
 
+       value
+            Sets the starting value of the field
+
         size
             Controls the size of the rendered ``div.form-group`` through the use of CSS classes.
 
@@ -450,20 +453,20 @@ def bootstrap_field(*args, **kwargs):
         addon_before
             Text that should be prepended to the form field. Can also be an icon, e.g.
             ``'<span class="glyphicon glyphicon-calendar"></span>'``
-            
+
             See the `Bootstrap docs <http://getbootstrap.com/components/#input-groups-basic>` for more examples.
 
         addon_after
             Text that should be appended to the form field. Can also be an icon, e.g.
             ``'<span class="glyphicon glyphicon-calendar"></span>'``
-            
+
             See the `Bootstrap docs <http://getbootstrap.com/components/#input-groups-basic>` for more examples.
 
         addon_before_class
             Class used on the span when ``addon_before`` is used.
 
             One of the following values:
-                
+
                 * ``'input-group-addon'``
                 * ``'input-group-btn'``
 
@@ -473,7 +476,7 @@ def bootstrap_field(*args, **kwargs):
             Class used on the span when ``addon_after`` is used.
 
             One of the following values:
-                
+
                 * ``'input-group-addon'``
                 * ``'input-group-btn'``
 

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -50,7 +50,7 @@ class TestForm(forms.Form):
         max_length=100,
         help_text='my_help_text',
         required=True,
-        widget=forms.TextInput(attrs={'placeholder': 'placeholdertest'}),
+        widget=forms.TextInput(attrs={'placeholder': 'placeholdertest', 'value': 'Subject!'}),
     )
     password = forms.CharField(widget=forms.PasswordInput)
     message = forms.CharField(required=False, help_text='<i>my_help_text</i>')
@@ -399,6 +399,7 @@ class FieldTest(TestCase):
         res = render_form_field('subject')
         self.assertIn('type="text"', res)
         self.assertIn('placeholder="placeholdertest"', res)
+        self.assertIn('value="Subject!"', res)
 
     def test_password(self):
         res = render_form_field('password')


### PR DESCRIPTION
Adding a value option so you can specify the value of textboxes like this, useful for when you want to auto fill for the user.

```{% bootstrap_field form.email value="test@example.com" %}```