### PR TITLE
Add: Feature request #380

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -161,6 +161,7 @@ class FormRenderer(BaseRenderer):
         if DBS3_SET_REQUIRED_SET_DISABLED and self.form.empty_permitted:
             self.set_required = False
 
+        self.errors_type = kwargs.get('errors_type', 'all')
         self.error_css_class = kwargs.get('error_css_class', None)
         self.required_css_class = kwargs.get('required_css_class', None)
         self.bound_css_class = kwargs.get('bound_css_class', None)
@@ -196,13 +197,15 @@ class FormRenderer(BaseRenderer):
                 form_errors += field.errors
         return form_errors
 
-    def render_errors(self, type='all'):
+    def render_errors(self):
         form_errors = None
-        if type == 'all':
-            form_errors = self.get_fields_errors() + self.form.non_field_errors()
-        elif type == 'fields':
+        if self.errors_type == 'all':
+            form_errors = (
+                self.get_fields_errors() + self.form.non_field_errors()
+            )
+        elif self.errors_type == 'fields':
             form_errors = self.get_fields_errors()
-        elif type == 'non_fields':
+        elif self.errors_type == 'non_fields':
             form_errors = self.form.non_field_errors()
 
         if form_errors:
@@ -212,7 +215,7 @@ class FormRenderer(BaseRenderer):
                     'errors': form_errors,
                     'form': self.form,
                     'layout': self.layout,
-                    'type': type,
+                    'type': self.errors_type,
                 }
             )
 

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -317,6 +317,17 @@ def bootstrap_form(*args, **kwargs):
             A list of field names (comma separated) that should not be rendered
             E.g. exclude=subject,bcc
 
+        errors_type
+            Control which type of errors should be rendered.
+
+            One of the following values:
+
+                * ``'all'``
+                * ``'fields'``
+                * ``'non_fields'``
+
+            :default: ``'all'``
+
         See bootstrap_field_ for other arguments
 
     **Usage**::

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -375,6 +375,75 @@ class FormTest(TestCase):
         )
         self.assertNotIn('bootstrap3-bound', res)
 
+    def test_errors_type(self):
+        form = TestForm({'sender': 'sender'})
+
+        res = render_template_with_form('{% bootstrap_form form %}', {'form': form})
+        pattern = re.compile(r'\s+')
+        expected = """
+    <div class="alert alert-danger alert-dismissable alert-link">
+        <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&#215;</button>
+        This field is required.<br>
+        This field is required.<br>
+        Enter a valid email address.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This error was added to show the non field errors styling.
+    </div>
+"""
+        self.assertIn(
+            re.sub(pattern, '', expected),
+            re.sub(pattern, '', res)
+        )
+
+        res = render_template_with_form(
+            '{% bootstrap_form form errors_type="non_fields" %}',
+            {'form': form}
+        )
+        expected = """
+    <div class="alert alert-danger alert-dismissable alert-link">
+        <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&#215;</button>
+        This error was added to show the non field errors styling.
+    </div>
+"""
+        self.assertIn(
+            re.sub(pattern, '', expected),
+            re.sub(pattern, '', res)
+        )
+
+        res = render_template_with_form(
+            '{% bootstrap_form form errors_type="fields" %}',
+            {'form': form}
+        )
+        expected = """
+    <div class="alert alert-danger alert-dismissable alert-link">
+        <button class="close" type="button" data-dismiss="alert" aria-hidden="true">&#215;</button>
+        This field is required.<br>
+        This field is required.<br>
+        Enter a valid email address.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.<br>
+        This field is required.
+    </div>
+"""
+        self.assertIn(
+            re.sub(pattern, '', expected),
+            re.sub(pattern, '', res)
+        )
+
 
 class FieldTest(TestCase):
     def test_illegal_field(self):


### PR DESCRIPTION
Add `errors_type` support in the `{% bootstrap_form %}` tag.