### PR TITLE
Fix invalid html around help texts and errors

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -463,7 +463,7 @@ class FieldRenderer(BaseRenderer):
                     'show_help': self.show_help,
                 }
             )
-            html += '<span class="help-block">{help}</span>'.format(help=help_html)
+            html += help_html
         return html
 
     def get_field_class(self):


### PR DESCRIPTION
Hi,

help texts are currently put inside a div inside a span, which is invalid html. And since both elements just set the class to "help-block", this also seems unnecessary. Looking at `git log bootstrap3/templates/bootstrap3/field_help_text_and_errors.html`, it looks like an oversight.

I'm not sure whether div or span is preferable, so I just left the template as it is with divs.