### PR TITLE
Fix placeholder not showing on Django 1.11

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.contrib.admin.widgets import AdminFileWidget
 from django.forms import (
     HiddenInput, FileInput, CheckboxSelectMultiple, Textarea, TextInput,
-    PasswordInput
+    PasswordInput, NumberInput, EmailInput, URLInput,
 )
 from django.forms.widgets import CheckboxInput
 from django.utils.safestring import mark_safe
@@ -183,4 +183,5 @@ def is_widget_with_placeholder(widget):
     """
     # PasswordInput inherits from Input in Django 1.4.
     # It was changed to inherit from TextInput in 1.5.
-    return isinstance(widget, (TextInput, Textarea, PasswordInput))
+    return isinstance(widget, (TextInput, Textarea, NumberInput, EmailInput,
+                               URLInput, PasswordInput))

--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -179,9 +179,6 @@ def is_widget_with_placeholder(widget):
     """
     Is this a widget that should have a placeholder?
     Only text, search, url, tel, e-mail, password, number have placeholders
-    These are all derived form TextInput, except for Textarea
     """
-    # PasswordInput inherits from Input in Django 1.4.
-    # It was changed to inherit from TextInput in 1.5.
     return isinstance(widget, (TextInput, Textarea, NumberInput, EmailInput,
                                URLInput, PasswordInput))

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -704,3 +704,9 @@ class ShowLabelTest(TestCase):
             res.strip(),
             '<button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-info-sign"></span> test</button>'
         )
+
+
+class ShowPlaceholderTest(TestCase):
+    def test_placeholder_set_from_label(self):
+        res = render_form_field('sender')
+        self.assertIn('placeholder="Sender © unicode"', res)


### PR DESCRIPTION
#387

test case is rather bare, and relies on defaults. may be worth beefing it up a bit.