### PR TITLE
Example of how to append other GET parameters

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -829,6 +829,7 @@ def bootstrap_pagination(page, **kwargs):
     **Example**::
 
         {% bootstrap_pagination lines url="/pagination?page=1" size="large" %}
+        {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
 
     """
 


### PR DESCRIPTION
It took me forever to find out how to append other GET parameters (e.g. from forms) to the pagination url. I think this is a very common use case and should be an example.