### PR TITLE
Satisfies #380: Adds ‘errors_types’ support in bootstrap_form tag

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Contributors
 * Jordan Starcher <jstarcher@gmail.com>
 * Juan Carlos <juancarlospaco@gmail.com>
 * Markus Holtermann <info@markusholtermann.eu>
+* Martin Koistinen <mkoistinen@gmail.com>
 * Nick S <nsmith448@gmail.com>
 * Owais Lone <loneowais@gmail.com>
 * pmav99 <pmav99@users.noreply.github.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Development (in progress)
 +++++++++++++++++++++++++
 
 * Renamed requirements-dev.txt back to requirements.txt because that suits ReadTheDocs better
+* Added 'errors_type' support on bootstrap3_form (thanks @mkoistinen)
 
 
 8.2.3 (2017-05-05)

--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -166,6 +166,7 @@ class FormRenderer(BaseRenderer):
         if DBS3_SET_REQUIRED_SET_DISABLED and self.form.empty_permitted:
             self.set_required = False
 
+        self.errors_type = kwargs.get('errors_type', 'all')
         self.error_css_class = kwargs.get('error_css_class', None)
         self.required_css_class = kwargs.get('required_css_class', None)
         self.bound_css_class = kwargs.get('bound_css_class', None)
@@ -202,7 +203,7 @@ class FormRenderer(BaseRenderer):
         return form_errors
 
     def render_errors(self, type='all'):
-        form_errors = None
+        form_errors = []
         if type == 'all':
             form_errors = self.get_fields_errors() + self.form.non_field_errors()
         elif type == 'fields':
@@ -224,7 +225,7 @@ class FormRenderer(BaseRenderer):
         return ''
 
     def _render(self):
-        return self.render_errors() + self.render_fields()
+        return self.render_errors(self.errors_type) + self.render_fields()
 
 
 class FieldRenderer(BaseRenderer):

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -318,6 +318,13 @@ def bootstrap_form(*args, **kwargs):
             A list of field names (comma separated) that should not be rendered
             E.g. exclude=subject,bcc
 
+        errors_type
+            This controls the types of errors that are rendered above the form.
+            Choices are: "all", "fields", "non_fields" or "none". This will not
+            affect the display of errors on the fields themselves.
+
+            Default is "all".
+
         See bootstrap_field_ for other arguments
 
     **Usage**::


### PR DESCRIPTION
Apologies to @ikcam, I had developed this independently.

Though, now that I see his, I wonder if this one is cleaner. His does have a test though =) I'll leave it to the maintainers to pick which way to go, but *please pick one and make a release*. Thank you!