### PR TITLE
Correct example for alert-danger

### DIFF
--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -679,7 +679,7 @@ def bootstrap_alert(content, alert_type='info', dismissable=True):
 
     **Example**::
 
-        {% bootstrap_alert "Something went wrong" alert_type='error' %}
+        {% bootstrap_alert "Something went wrong" alert_type='danger' %}
 
     """
     return render_alert(content, alert_type, dismissable)


### PR DESCRIPTION
Fix a minor issue in the example `error` should be `danger`