### PR TITLE
Add extra parameters to HTML tag and convert data tags for bootstrap_…

### DIFF
--- a/bootstrap3/forms.py
+++ b/bootstrap3/forms.py
@@ -16,7 +16,7 @@ from .bootstrap import (
 from .components import render_icon
 from .exceptions import BootstrapError
 from .text import text_concat, text_value
-from .utils import add_css_class, render_tag
+from .utils import add_css_class, render_tag, convert_data_attrs
 
 FORM_GROUP_CLASS = 'form-group'
 
@@ -69,7 +69,8 @@ def render_field(field, **kwargs):
     return renderer_cls(field, **kwargs).render()
 
 
-def render_label(content, label_for=None, label_class=None, label_title=''):
+def render_label(content, label_for=None, label_class=None, label_title='',
+                 **kwargs):
     """
     Render a label with content
     """
@@ -80,12 +81,15 @@ def render_label(content, label_for=None, label_class=None, label_title=''):
         attrs['class'] = label_class
     if label_title:
         attrs['title'] = label_title
+    # allow any other tag attributes to be specified as arguments to
+    # `bootstrap_label`
+    attrs.update(convert_data_attrs(kwargs))
     return render_tag('label', attrs=attrs, content=content)
 
 
 def render_button(
         content, button_type=None, icon=None, button_class='btn-default', size='',
-        href='', name=None, value=None, title=None, extra_classes='', id=''):
+        href='', name=None, value=None, title=None, extra_classes='', id='', **kwargs):
     """
     Render a button with content
     """
@@ -126,6 +130,9 @@ def render_button(
         attrs['value'] = value
     if title:
         attrs['title'] = title
+    # allow any other tag attributes to be specified as arguments to
+    # `bootstrap_button`
+    attrs.update(convert_data_attrs(kwargs))
     return render_tag(
         tag,
         attrs=attrs,

--- a/bootstrap3/templatetags/bootstrap3.py
+++ b/bootstrap3/templatetags/bootstrap3.py
@@ -539,6 +539,12 @@ def bootstrap_label(*args, **kwargs):
         label_title
             The value that will be in the ``title`` attribute of the rendered ``<label>``
 
+        \*\*kwargs
+            Additional attributes that will be set on the generated HTML tag.
+            Keys starting with ``"data_"`` will have *all* underscores
+            (``"_"``) replaced with hyphens (``"-"``) for compatibility with
+            data attributes.
+
     **Usage**::
 
         {% bootstrap_label content %}
@@ -605,6 +611,12 @@ def bootstrap_button(*args, **kwargs):
 
         value
             Value of the ``value`` attribute of the rendered element.
+
+        \*\*kwargs
+            Additional attributes that will be set on the generated HTML tag.
+            Keys starting with ``"data_"`` will have *all* underscores
+            (``"_"``) replaced with hyphens (``"-"``) for compatibility with
+            data attributes.
 
     **Usage**::
 

--- a/bootstrap3/tests.py
+++ b/bootstrap3/tests.py
@@ -13,7 +13,7 @@ from django.test import TestCase, override_settings
 from .bootstrap import DBS3_SET_REQUIRED_SET_DISABLED
 from .exceptions import BootstrapError
 from .text import text_value, text_concat
-from .utils import add_css_class, render_tag
+from .utils import add_css_class, render_tag, convert_data_attrs
 
 try:
     from html.parser import HTMLParser
@@ -574,6 +574,12 @@ class FieldTest(TestCase):
         res = render_template_with_form('{% bootstrap_label "foobar" label_for="subject" %}')
         self.assertEqual('<label for="subject">foobar</label>', res)
 
+    def test_extra_label_attributes(self):
+        res = render_template_with_form('{% bootstrap_label "spam" data_attr_quest="to_seek_the_holy_grail" %}')
+        self.assertIn('data-attr-quest="to_seek_the_holy_grail"', res)
+        res = render_template_with_form('{% bootstrap_label "swallow" african_or_european="unknown" %}')
+        self.assertIn('african_or_european="unknown"', res)
+
     def test_attributes_consistency(self):
         form = TestForm()
         attrs = form.fields['addon'].widget.attrs.copy()
@@ -744,6 +750,18 @@ class UtilsTest(TestCase):
             '<span bar="123">foo</span>'
         )
 
+    def test_convert_data_attrs(self):
+        self.assertEqual(
+            convert_data_attrs({
+                "spam_eggs": "spam",
+                "data_camelot_place_type": "silly",
+            }),
+            {
+                "spam_eggs": "spam",
+                "data-camelot-place-type": "silly",
+            }
+        )
+
 
 class ButtonTest(TestCase):
     def test_button(self):
@@ -755,6 +773,12 @@ class ButtonTest(TestCase):
             res.strip(),
             '<a class="btn btn-default btn-lg" href="#">button</a><a href="#" ' +
             'class="btn btn-lg">button</a>')
+
+    def test_additional_attributes(self):
+        res = render_template_with_form("{% bootstrap_button 'button' 'submit' formaction='test_formaction' %}")
+        self.assertIn('formaction="test_formaction"', res.strip())
+        res = render_template_with_form("{% bootstrap_button 'button' data_attr_beast_location='caerbannog' %}")
+        self.assertIn('data-attr-beast-location="caerbannog"', res.strip())
 
 
 class ShowLabelTest(TestCase):

--- a/bootstrap3/utils.py
+++ b/bootstrap3/utils.py
@@ -150,6 +150,23 @@ def render_template_file(template, context=None):
     return template.render(context)
 
 
+def _convert_data_attrs_key(key):
+    if key.startswith("data_"):
+        return key.replace("_", "-")
+    return key
+
+
+def convert_data_attrs(attrs):
+    """
+    Replace "_" with "-" for keys that start with "data_".
+    Used to allow passing HTML data attributes (that must contain a "-") as
+    templatetag parameters (that may not contain a "-").
+    """
+    return {
+        _convert_data_attrs_key(k): v for k, v in attrs.items()
+    }
+
+
 def url_replace_param(url, name, value):
     """
     Replace a GET parameter in an URL


### PR DESCRIPTION
…button and bootstrap_label

Implements #376 

I made a possibly controversial decision when I implemented this - parameters that start with `"data_"` get their underscores converted to hyphens. This is because data attribute names **must** start with the string `"data-"`, but anything that fits that is not a valid identifier and can't be passed from Django templates.

On the other hand, blind conversion might be a bad idea? It would, however, be more consistent.

In any case, making it consistent is a matter of simplifying the code, so I'm just going to leave it that way, and am open to changing it.