### PR TITLE
PasswordInput: enabling addons in Django 1.11

### DIFF
--- a/bootstrap3/renderers.py
+++ b/bootstrap3/renderers.py
@@ -20,6 +20,7 @@ from django.forms import (
     NumberInput,
     EmailInput,
     URLInput,
+    PasswordInput,
 )
 
 # Django 1.9 moved SelectDateWidget to django.forms.widget from
@@ -482,7 +483,7 @@ class FieldRenderer(BaseRenderer):
     def make_input_group(self, html):
         if (self.addon_before or self.addon_after) and isinstance(
             self.widget,
-            (TextInput, NumberInput, EmailInput, URLInput, DateInput, Select),
+            (TextInput, NumberInput, EmailInput, URLInput, DateInput, Select, PasswordInput),
         ):
             before = (
                 '<span class="{input_class}">{addon}</span>'.format(


### PR DESCRIPTION
At least in Django 1.11 (not sure in which version this change was introduced), `PasswordInput` is no longe a subclass of `TextInput` and is therefore nor recognised in the check in the `make_input_group` method. This prevents the `addon_before` and `addon_after`options to work on these fields.
This is fixed in this commit.